### PR TITLE
Print output as it comes in.

### DIFF
--- a/bin/test_setup
+++ b/bin/test_setup
@@ -10,7 +10,7 @@ if [ ! -d .venv ]; then
     . .venv/bin/activate
     pip install --upgrade pip
     pip install wheel
-    pip install --use-wheel -f deps --no-index -r requirements.txt
+    pip install --use-wheel -f deps -r requirements.txt
     pip install --use-wheel -f deps --no-index .
 fi
 

--- a/bundletester/runner.py
+++ b/bundletester/runner.py
@@ -56,6 +56,12 @@ class Runner(object):
             stderr=subprocess.STDOUT,
             cwd=self.options.testdir,
         )
+
+        # Print all output as it comes in to debug
+        lines = iter(p.stdout.readline, "")
+        for line in lines:
+            log.debug(str(line.rstrip()))
+
         output, _ = p.communicate()
         retcode = p.returncode
         log.debug("\n%s" % output)


### PR DESCRIPTION
When using -l DEBUG, print output of external commands as they come in.  This helps when your integration suite takes 10 minutes to run. :)
