### PR TITLE
Minor fixes to extend bundle handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 dist/
 build/
 .bzr/
@@ -5,3 +6,5 @@ build/
 *.egg-info/
 *.pyc
 *.py.~*
+/.coverage
+/.cover/

--- a/bundletester/builder.py
+++ b/bundletester/builder.py
@@ -43,7 +43,7 @@ class Builder(object):
         result = {
             'returncode': 0
         }
-        bundle = bundle or self.options.bundle
+        bundle = bundle or self.options.bundle.path
         if not bundle:
             return result
         if not os.path.exists(bundle):

--- a/bundletester/builder.py
+++ b/bundletester/builder.py
@@ -43,7 +43,7 @@ class Builder(object):
         result = {
             'returncode': 0
         }
-        bundle = bundle or self.options.bundle.path
+        bundle = bundle or self.options.bundle
         if not bundle:
             return result
         if not os.path.exists(bundle):

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -182,10 +182,13 @@ def filter_yamls(yamls):
     return result
 
 
-def find_bundle_file(directory, bundle):
+def find_bundle_file(directory, bundle, filter_yamls=filter_yamls):
     if bundle.path is not None:
-        return bundle.path
-
+        if bundle.explicit_path is True:
+            return bundle.path
+        bp = os.path.join(directory, bundle.path)
+        assert os.path.exists(bp)
+        return bp
     pat = os.path.join(directory, "*.yaml")
     yamls = glob.glob(pat)
     yamls = filter_yamls(yamls)

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -183,11 +183,10 @@ def filter_yamls(yamls):
 
 
 def find_bundle_file(directory, bundle, filter_yamls=filter_yamls):
-    if bundle.path is not None:
-        if bundle.explicit_path is True:
-            return bundle.path
-        bp = os.path.join(directory, bundle.path)
-        assert os.path.exists(bp)
+    if bundle is not None:
+        bp = os.path.join(directory, bundle)
+        if not os.path.exists(bp):
+            raise OSError("%s not found" % bp)
         return bp
     pat = os.path.join(directory, "*.yaml")
     yamls = glob.glob(pat)

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -25,16 +25,20 @@ def validate():
 
 
 class BundleSpec(object):
-    def __init__(self, path=None, name=None):
+    def __init__(self, path=None, name=None, explicit_path=True):
         self.path = path
         self.name = name
+        self.explicit_path = explicit_path
 
     @staticmethod
     def validate_path(path):
-        bp = os.path.abspath(os.path.expanduser(path))
-        if not os.path.exists(bp):
-            raise argparse.ArgumentTypeError("%s not found on filesystem" % bp)
-        return bp
+        if any((path.startswith(x) for x in ('~', '/', '.'))):
+            bp = os.path.abspath(os.path.expanduser(path))
+            if not os.path.exists(bp):
+                raise argparse.\
+                    ArgumentTypeError("%s not found on filesystem" % bp)
+            return bp, True
+        return path, False
 
     @classmethod
     def parse_cli(cls, spec):
@@ -43,10 +47,10 @@ class BundleSpec(object):
 
         if any(sp[0].endswith(y) for y in ('.yml', '.yaml')):
             candidate = sp.pop(0)
-            path = cls.validate_path(candidate)
+            path, explicit = cls.validate_path(candidate)
             if len(sp):
                 name = sp[0]
-            return cls(path, name)
+            return cls(path, name, explicit)
 
         name = sp[0]
         return cls(path, name)

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -101,6 +101,9 @@ def main():
     if not options.output:
         options.output = sys.stdout
 
+    if options.bundle.name and not options.deployment:
+        options.deployment = options.bundle.name
+
     try:
         fetcher = fetchers.get_fetcher(options.testdir)
         options.testdir = fetcher.fetch(

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -82,10 +82,7 @@ def main():
         sys.stderr.write("{}\n".format(e))
         sys.exit(1)
 
-    try:
-        suite = spec.SuiteFactory(options, options.testdir)
-    except :
-        import pdb;pdb.post_mortem(sys.exc_info()[2])
+    suite = spec.SuiteFactory(options, options.testdir)
 
     if not suite:
         sys.stderr.write("No Tests Found\n")

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -27,7 +27,6 @@ def validate():
 class BundleSpec(object):
     def __init__(self, path=None, name=None, explicit_path=True):
         self.path = path
-        self.name = name
         self.explicit_path = explicit_path
 
     @staticmethod
@@ -42,18 +41,12 @@ class BundleSpec(object):
 
     @classmethod
     def parse_cli(cls, spec):
-        sp = spec.split(":")
-        name, path = None, None
-
-        if any(sp[0].endswith(y) for y in ('.yml', '.yaml')):
-            candidate = sp.pop(0)
+        if any(spec.endswith(y) for y in ('.yml', '.yaml')):
+            candidate = spec
             path, explicit = cls.validate_path(candidate)
-            if len(sp):
-                name = sp[0]
-            return cls(path, name, explicit)
+            return cls(path, explicit)
 
-        name = sp[0]
-        return cls(path, name)
+        return cls(spec)
 
 
 def configure():

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -25,7 +25,7 @@ def validate():
 
 
 class BundleSpec(object):
-    def __init__(self, path, name):
+    def __init__(self, path=None, name=None):
         self.path = path
         self.name = name
 
@@ -59,6 +59,7 @@ def configure():
     parser.add_argument('-t', '--testdir', default=os.getcwd())
     parser.add_argument('-b', '-c', '--bundle',
                         type=BundleSpec.parse_cli,
+                        default=BundleSpec(),
                         help=textwrap.dedent("""
                         Specify a bundle ala
                         {/path/to/bundle.yaml}:{bundle_name}. Either

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -66,8 +66,8 @@ def configure():
                         default=BundleSpec(),
                         help=textwrap.dedent("""
                         Specify a bundle ala
-                        {/path/to/bundle.yaml}:{bundle_name}. Either
-                        path or name is optional
+                        {path/to/bundle.yaml}. Relative paths will be mapped
+                        within the bundle itself for remote bundles
                         """))
     parser.add_argument('-d', '--deployment')
 
@@ -104,9 +104,6 @@ def main():
 
     if not options.output:
         options.output = sys.stdout
-
-    if options.bundle.name and not options.deployment:
-        options.deployment = options.bundle.name
 
     try:
         fetcher = fetchers.get_fetcher(options.testdir)

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -24,44 +24,19 @@ def validate():
     subprocess.check_output(['juju', 'version'])
 
 
-class BundleSpec(object):
-    def __init__(self, path=None, explicit_path=True):
-        self.path = path
-        self.explicit_path = explicit_path
-
-    @staticmethod
-    def validate_path(path):
-        if any((path.startswith(x) for x in ('~', '/', '.'))):
-            bp = os.path.abspath(os.path.expanduser(path))
-            if not os.path.exists(bp):
-                raise argparse.\
-                    ArgumentTypeError("%s not found on filesystem" % bp)
-            return bp, True
-        return path, False
-
-    @classmethod
-    def parse_cli(cls, spec):
-        import pdb;pdb.set_trace()
-        if any(spec.endswith(y) for y in ('.yml', '.yaml')):
-            candidate = spec
-            path, explicit = cls.validate_path(candidate)
-            return cls(path, explicit)
-
-        return cls(spec)
-
-
 def configure():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('-e', '--environment')
     parser.add_argument('-t', '--testdir', default=os.getcwd())
     parser.add_argument('-b', '-c', '--bundle',
-                        type=BundleSpec.parse_cli,
-                        default=BundleSpec(),
+                        type=str,
                         help=textwrap.dedent("""
                         Specify a bundle ala
-                        {path/to/bundle.yaml}. Relative paths will be mapped
-                        within the bundle itself for remote bundles
+                        {path/to/bundle.yaml}. Relative paths will be
+                        mapped within the bundle itself for remote
+                        bundles. Explicit local paths to bundles
+                        currently not supported.
                         """))
     parser.add_argument('-d', '--deployment')
 

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -25,7 +25,7 @@ def validate():
 
 
 class BundleSpec(object):
-    def __init__(self, path=None, name=None, explicit_path=True):
+    def __init__(self, path=None, explicit_path=True):
         self.path = path
         self.explicit_path = explicit_path
 
@@ -41,6 +41,7 @@ class BundleSpec(object):
 
     @classmethod
     def parse_cli(cls, spec):
+        import pdb;pdb.set_trace()
         if any(spec.endswith(y) for y in ('.yml', '.yaml')):
             candidate = spec
             path, explicit = cls.validate_path(candidate)
@@ -106,7 +107,11 @@ def main():
         sys.stderr.write("{}\n".format(e))
         sys.exit(1)
 
-    suite = spec.SuiteFactory(options, options.testdir)
+    try:
+        suite = spec.SuiteFactory(options, options.testdir)
+    except :
+        import pdb;pdb.post_mortem(sys.exc_info()[2])
+
     if not suite:
         sys.stderr.write("No Tests Found\n")
         sys.exit(3)

--- a/tests/test_bundlespec.py
+++ b/tests/test_bundlespec.py
@@ -38,5 +38,6 @@ class TestFindBundleFile(unittest.TestCase):
             with self.assertRaises(OSError):
                 fbf()
 
-    def test_find_bundle_file_explicit(self):
-        assert self.makeone(path="/wat", explicit=True)() == '/wat'
+    def test_find_bundle_file_explicit_raise(self):
+        with self.assertRaises(OSError):
+            assert self.makeone(path="/wat")()

--- a/tests/test_bundlespec.py
+++ b/tests/test_bundlespec.py
@@ -23,20 +23,12 @@ class TestBundleSpec(unittest.TestCase):
 
     def test_bundle_spec_name_only(self):
         spec = self.makeone("devel")
-        assert spec.path is None
-        assert spec.name == 'devel'
+        assert spec.path is "devel"
 
     def test_bundle_spec_path_only(self):
         spec = self.makeone(self.lb)
         assert spec.path.startswith('/')
         assert spec.path.endswith('watcher/bundle.yaml')
-        assert spec.name is None
-
-    def test_bundle_spec_path_and_name(self):
-        spec = self.makeone(self.lb + ":"  + "wat")
-        assert spec.path.startswith('/')
-        assert spec.path.endswith('watcher/bundle.yaml')
-        assert spec.name == 'wat'
 
 
 class TestFindBundleFile(unittest.TestCase):

--- a/tests/test_bundlespec.py
+++ b/tests/test_bundlespec.py
@@ -1,11 +1,14 @@
-import unittest
+from functools import partial
+from mock import patch
 import argparse
 import os
+import unittest
 
 
 class TestBundleSpec(unittest.TestCase):
-    lb = os.path.join(os.path.abspath(os.path.dirname(__file__)),
-                      "watcher/bundle.yaml")
+    here = os.path.abspath(os.path.dirname(__file__))
+    lb = os.path.join(here, "watcher/bundle.yaml")
+
     def makeone(self, spec):
         from bundletester.tester import BundleSpec
         return BundleSpec.parse_cli(spec)
@@ -13,6 +16,10 @@ class TestBundleSpec(unittest.TestCase):
     def test_bundle_spec_error(self):
         with self.assertRaises(argparse.ArgumentTypeError):
             self.makeone("/tmp/belching-balrog.yaml")
+
+    def test_bundle_spec_error_not_raised_relative_path(self):
+        spec = self.makeone("belching-balrog.yaml")
+        assert spec.path == "belching-balrog.yaml"
 
     def test_bundle_spec_name_only(self):
         spec = self.makeone("devel")
@@ -30,3 +37,41 @@ class TestBundleSpec(unittest.TestCase):
         assert spec.path.startswith('/')
         assert spec.path.endswith('watcher/bundle.yaml')
         assert spec.name == 'wat'
+
+
+class TestFindBundleFile(unittest.TestCase):
+    here = os.path.abspath(os.path.dirname(__file__))
+
+    def makeone(self, path=TestBundleSpec.lb, explicit=True, directory=here):
+        from bundletester.tester import BundleSpec
+        from bundletester.spec import find_bundle_file
+        return partial(find_bundle_file,
+                       directory,
+                       BundleSpec(path=path, explicit_path=explicit),
+                       filter_yamls=lambda x:x)
+
+    def test_find_bundle_file_rel(self):
+        fbf = self.makeone(path="watcher/bundle.yaml", explicit=False)
+        out = fbf()
+        assert out.startswith('/')
+        assert out.endswith('watcher/bundle.yaml')
+
+    def test_find_bundle_file_unspecified(self):
+        fbf = self.makeone(path=None,
+                           directory=os.path.join(self.here, 'watcher'))
+        out = fbf()
+        assert out.startswith('/')
+        assert out.endswith('watcher/bundle.yaml')
+
+    def test_find_bundle_file_unspecified_empty(self):
+        fbf = self.makeone(path=None)
+        assert fbf() is None
+
+    def test_find_bundle_file_unspecified_ambiguous_raises(self):
+        with patch('glob.glob', return_value=["a.yaml", "b.yaml"]) as g:
+            fbf = self.makeone(path=None)
+            with self.assertRaises(OSError):
+                fbf()
+
+    def test_find_bundle_file_explicit(self):
+        assert self.makeone(path="/wat", explicit=True)() == '/wat'

--- a/tests/test_bundlespec.py
+++ b/tests/test_bundlespec.py
@@ -1,45 +1,18 @@
 from functools import partial
 from mock import patch
-import argparse
 import os
 import unittest
 
 
-class TestBundleSpec(unittest.TestCase):
+class TestFindBundleFile(unittest.TestCase):
     here = os.path.abspath(os.path.dirname(__file__))
     lb = os.path.join(here, "watcher/bundle.yaml")
 
-    def makeone(self, spec):
-        from bundletester.tester import BundleSpec
-        return BundleSpec.parse_cli(spec)
-
-    def test_bundle_spec_error(self):
-        with self.assertRaises(argparse.ArgumentTypeError):
-            self.makeone("/tmp/belching-balrog.yaml")
-
-    def test_bundle_spec_error_not_raised_relative_path(self):
-        spec = self.makeone("belching-balrog.yaml")
-        assert spec.path == "belching-balrog.yaml"
-
-    def test_bundle_spec_name_only(self):
-        spec = self.makeone("devel")
-        assert spec.path is "devel"
-
-    def test_bundle_spec_path_only(self):
-        spec = self.makeone(self.lb)
-        assert spec.path.startswith('/')
-        assert spec.path.endswith('watcher/bundle.yaml')
-
-
-class TestFindBundleFile(unittest.TestCase):
-    here = os.path.abspath(os.path.dirname(__file__))
-
-    def makeone(self, path=TestBundleSpec.lb, explicit=True, directory=here):
-        from bundletester.tester import BundleSpec
+    def makeone(self, path=lb, explicit=True, directory=here):
         from bundletester.spec import find_bundle_file
         return partial(find_bundle_file,
                        directory,
-                       BundleSpec(path=path, explicit_path=explicit),
+                       path,
                        filter_yamls=lambda x:x)
 
     def test_find_bundle_file_rel(self):

--- a/tests/test_bundlespec.py
+++ b/tests/test_bundlespec.py
@@ -1,0 +1,32 @@
+import unittest
+import argparse
+import os
+
+
+class TestBundleSpec(unittest.TestCase):
+    lb = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                      "watcher/bundle.yaml")
+    def makeone(self, spec):
+        from bundletester.tester import BundleSpec
+        return BundleSpec.parse_cli(spec)
+
+    def test_bundle_spec_error(self):
+        with self.assertRaises(argparse.ArgumentTypeError):
+            self.makeone("/tmp/belching-balrog.yaml")
+
+    def test_bundle_spec_name_only(self):
+        spec = self.makeone("devel")
+        assert spec.path is None
+        assert spec.name == 'devel'
+
+    def test_bundle_spec_path_only(self):
+        spec = self.makeone(self.lb)
+        assert spec.path.startswith('/')
+        assert spec.path.endswith('watcher/bundle.yaml')
+        assert spec.name is None
+
+    def test_bundle_spec_path_and_name(self):
+        spec = self.makeone(self.lb + ":"  + "wat")
+        assert spec.path.startswith('/')
+        assert spec.path.endswith('watcher/bundle.yaml')
+        assert spec.name == 'wat'


### PR DESCRIPTION
The kubernetes bundle has multiple bundle files in the root and is moving to using inheritance.  These changes improve both situations.

- allow for --bundle to overide ambiguous yaml error
- add idea of bundle spec to pass to --bundle ala: ` {path/to/bundle.yaml}:bundle_name`.
- alias bundle_name when deployment not specified