### PR TITLE
Set an envrionment variable if the bundle argument was set.

### DIFF
--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -63,6 +63,9 @@ def configure():
 
     if not options.environment:
         options.environment = current_environment()
+    # Set the environment variable BUNDLE if the bundle argument was provided.
+    if options.bundle:
+        os.environ['BUNDLE'] = options.bundle
     logging.basicConfig(level=options.log_level)
     return options
 


### PR DESCRIPTION
I have tested this change and it works for setting the BUNDLE environment variable when the --bundle option is set.