### PR TITLE
Adding description metadata to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ SETUP = {
     'url': "https://github.com/juju-solutions/bundletester",
     'license': "Affero GNU Public License v3",
     'long_description': open('README.md').read(),
+    'description': 'A juju charm and bundle test runner',
     'entry_points': {
         'console_scripts': [
             'bundletester = bundletester.tester:main',


### PR DESCRIPTION
Adding `description` metadata to `setup.py` to be picked up by `pypi` so that it does not show `UNKNOWN`