### PR TITLE
Updated sys.exit to return.

### DIFF
--- a/bundletester/reporter.py
+++ b/bundletester/reporter.py
@@ -94,8 +94,8 @@ class Reporter(object):
     def exit(self):
         for m in self.messages:
             if m['returncode'] != 0:
-                sys.exit(1)
-        sys.exit(0)
+                return 1
+        return 0
 
 
 class DotReporter(Reporter):

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -88,13 +88,13 @@ def main(options=None):
             tempfile.mkdtemp(prefix='bundletester-'))
     except fetchers.FetchError as e:
         sys.stderr.write("{}\n".format(e))
-        sys.exit(1)
+        return 1
 
     suite = spec.SuiteFactory(options, options.testdir)
 
     if not suite:
         sys.stderr.write("No Tests Found\n")
-        sys.exit(3)
+        return 3
 
     report = reporter.get_reporter(options.reporter, options.output, options)
     report.set_suite(suite)
@@ -104,8 +104,8 @@ def main(options=None):
         with utils.juju_env(options.environment):
             [report.emit(result) for result in run()]
     report.summary()
-    report.exit()
+    return report.exit()
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/bundletester/watcher.py
+++ b/bundletester/watcher.py
@@ -69,6 +69,7 @@ def main():
     if not options.revisions:
         options.revisions = os.path.join(curdir, 'revisions.json')
 
+    tmpdir = None
     if options.bundle_only is False:
         tmpdir = tempfile.mkdtemp()
         os.chdir(tmpdir)
@@ -80,7 +81,7 @@ def main():
         raise ValueError("%s missing YAML files" % options.bundle)
 
     if options.bundle_only:
-        sys.exit(0)
+        return 0
 
     c = ConfigStack(configs)
     if not options.deployment and len(c.keys()) == 1:
@@ -99,16 +100,17 @@ def main():
         current[charm.name] = get_bzr_revno(charm.path)
     existing = load_revisions(options.revisions)
 
-    shutil.rmtree(tmpdir)
+    if tmpdir:
+        shutil.rmtree(tmpdir)
     if current != existing:
         logging.debug("Recored revisions: %s" % options.revisions)
         record_revisions(options.revisions, current)
         logging.info("BUILD: exit 0")
-        sys.exit(0)
+        return 0
 
     logging.info("SKIP: exit 1")
-    sys.exit(1)
+    return 1
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Updated `sys.exit()` to `return` so that `bundletester` functions can be called externally without the program exiting during a failure.  