### PR TITLE
Install python packages via tests.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,40 +103,48 @@ A sample `tests.yaml` file::
 
     bootstrap: false
     reset: false
-    setup: script
-    teardown: script
-    tests: "[0-9]*"
     virtualenv: true
+    tests: "[0-9]*"
+    excludes:
+      - `filename`
     sources:
-        - ppas, etc
+      - ppa:ubuntu-lxc/lxd-stable
     packages:
-        - amulet
-        - python-requests
+      - lxd
+    python_packages:
+      - bzr
+      - juju-deployer
+      - amulet
+      - requests
     makefile:
-        - lint
-        - test
+      - lint
+      - test
+    setup: `filename`
+    teardown: `filename`
 
 Explanation of keys:
 
-**bootstrap**: Allow bootstrap of current env, default: true
+**bootstrap**: Bootstrap the environment if necessary (default: true).
 
-**reset**: Use juju-deployer to reset env between test, default: true
+**reset**: Use juju-deployer to reset the environment between each test file execution (default: true).
 
-**virtualenv**: create and activate a virtualenv in which all tests are run, default: false
+**virtualenv**: Create and activate a virtualenv in which all tests are run (default: false).
 
-**tests**: glob of executable files in testdir to treat as tests, default: "\*"
+**tests**: A glob pattern of executable files in the `tests/` directory to treat as tests (default: "\*"). Only files that match this pattern will be executed.
 
-**excludes**: list of charm names for which tests should be skipped
+**excludes**: List of charm names for which tests should be skipped. Useful if executing against a bundle.
 
-**sources**: list of package sources to add automatically
+**sources**: List of apt package sources to add before installing packages.
 
-**packages**: list of packages to install automatically with apt
+**packages**: List of packages to install with apt before running tests.
 
-**makefile**: list of make targets to execute, default: [lint, test]
+**python_packages**: List of python packages to install with `pip install -U` before running tests. If `virtualenv` is `true`, the packages will be installed in the virtualenv.
 
-**setup**: optional name of script in test dir to run before each test
+**makefile**: List of make targets to execute (default: [lint, test]).
 
-**teardown**: optional name of script to run after each test
+**setup**: Optional name of a script in the `tests/` directory to run before each test.
+
+**teardown**: Optional name of script in the `tests/` directory to run after each test.
 
 
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ A sample `tests.yaml` file::
     bootstrap: false
     reset: false
     virtualenv: true
+    virtualenv_python: python3
     tests: "[0-9]*"
     excludes:
       - `filename`
@@ -129,6 +130,10 @@ Explanation of keys:
 **reset**: Use juju-deployer to reset the environment between each test file execution (default: true).
 
 **virtualenv**: Create and activate a virtualenv in which all tests are run (default: false).
+
+**virtualenv_python**: The version of python with which to create the
+virtualenv (if `virtualenv` is `true'). Examples: python, python2.7,
+python3.5 (default: python).
 
 **tests**: A glob pattern of executable files in the `tests/` directory to treat as tests (default: "\*"). Only files that match this pattern will be executed.
 

--- a/bundletester/builder.py
+++ b/bundletester/builder.py
@@ -125,8 +125,9 @@ class Builder(object):
                 time.sleep(4)
 
     def build_virtualenv(self, path):
-        subprocess.check_call(['virtualenv', path],
-                              stdout=open('/dev/null', 'w'))
+        subprocess.check_call(
+            ['virtualenv', '-p', self.config.virtualenv_python, path],
+            stdout=open('/dev/null', 'w'))
 
     def add_source(self, source):
         subprocess.check_call(['sudo', 'apt-add-repository', '--yes', source])

--- a/bundletester/builder.py
+++ b/bundletester/builder.py
@@ -141,8 +141,16 @@ class Builder(object):
         subprocess.check_call(['sudo', 'apt-get', 'update', '-qq'])
 
     def install_packages(self):
-        if not self.config.packages:
-            return
-        cmd = ['sudo', 'apt-get', 'install', '-qq', '-y']
-        cmd.extend(self.config.packages)
-        subprocess.check_call(cmd)
+        if self.config.packages:
+            cmd = ['sudo', 'apt-get', 'install', '-qq', '-y']
+            cmd.extend(set(self.config.packages))
+            if (self.config.python_packages and
+                    subprocess.call(['which', 'pip']) != 0):
+                cmd.extend('python-pip')
+            subprocess.check_call(cmd)
+
+        if self.config.python_packages:
+            cmd = ['sudo'] if not self.config.virtualenv else []
+            cmd.extend(['pip', 'install', '-U'])
+            cmd.extend(set(self.config.python_packages))
+            subprocess.check_call(cmd)

--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -8,6 +8,7 @@ class Parser(dict):
             'reset': True,
             'bundle': None,
             'virtualenv': False,
+            'virtualenv_python': 'python',
             'tests': "*",
             'excludes': [],
             'sources': [],

--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -12,6 +12,7 @@ class Parser(dict):
             'excludes': [],
             'sources': [],
             'packages': [],
+            'python_packages': [],
             'makefile': ['lint', 'test'],
             'setup': [],
             'teardown': []

--- a/bundletester/runner.py
+++ b/bundletester/runner.py
@@ -114,6 +114,7 @@ class Runner(object):
         # can use that
         if self.suite.config.virtualenv and not os.environ.get("VIRTUAL_ENV"):
             vpath = os.path.join(self.options.testdir, '.venv')
+            log.debug('Creating virtualenv at %s', vpath)
             self.builder.build_virtualenv(vpath)
             apath = os.path.join(vpath, 'bin/activate_this.py')
             execfile(apath, dict(__file__=apath))


### PR DESCRIPTION
Adds new `python_packages` key to tests.yaml, a list of python packages to install with `pip install -U` before running tests. If `virtualenv` is `true`, the packages will be installed in the virtualenv.

Fixes #6