### PR TITLE
Ensure test arguments and/or test patterns match when specified

### DIFF
--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -160,9 +160,24 @@ class Suite(list):
             filterset = [os.path.join(self.testdir, f) for f
                          in self.options.tests]
             tests = tests.intersection(set(filterset))
+
+        exec_tests = []
         for test in sorted(tests):
             if os.path.isfile(test) and os.access(test, os.X_OK | os.R_OK):
+                exec_tests.append(test)
                 self.spec(test, dirname=self.model['directory'], suite=self)
+
+        # When a test pattern is provided, expect at least one executable
+        # glob match, otherwise fail.
+        if testpat and not exec_tests:
+            raise OSError('Expected at least one executable pattern '
+                          'match for: {}'.format(testpat))
+
+        # When one or more test name arguments are provided, expect ALL
+        # arguments to exist as executable files, otherwise fail.
+        if self.options.tests and len(self.options.tests) != len(exec_tests):
+            raise OSError('Expected executable test files: '
+                          '{}'.format(self.options.tests))
 
     def find_suite(self):
         """Find and prepend charms tests to our suite of tests.


### PR DESCRIPTION
This addresses issues where bundletester false test success is occurring: when one or more specific test names are declared as arguments, or a glob is defined as a test pattern, and no executable files match, that should be expected to fail.

Closes #54