### PR TITLE
Add support for use of requirements files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ A sample `tests.yaml` file::
       - juju-deployer
       - amulet
       - requests
+    requirements:
+      - test-requirements.txt
+      - requirements.txt
     makefile:
       - lint
       - test

--- a/bundletester/builder.py
+++ b/bundletester/builder.py
@@ -198,8 +198,12 @@ class Builder(object):
                 cmd.extend('python-pip')
             self._run_apt_command(cmd)
 
-        if self.config.python_packages:
+        if self.config.python_packages or self.config.requirements:
             cmd = ['sudo'] if not self.config.virtualenv else []
             cmd.extend(['pip', 'install', '-U'])
-            cmd.extend(set(self.config.python_packages))
+            for requirement in self.config.requirements:
+                if os.path.exists(requirement):
+                    cmd.extend(['--requirement', requirement])
+            if self.config.python_packages:
+                cmd.extend(set(self.config.python_packages))
             subprocess.check_call(cmd)

--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -17,6 +17,7 @@ class Parser(dict):
             'sources': [],
             'packages': [],
             'python_packages': [],
+            'requirements': [],
             'makefile': ['lint', 'test'],
             'setup': [],
             'teardown': []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,6 +22,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(parser.packages, [])
         self.assertEqual(parser.makefile, ['lint', 'test'])
         self.assertEqual(parser.setup, [])
+        self.assertEqual(parser.requirements, [])
 
     def test_config_parse(self):
         parser = config.Parser(locate('sample.yaml'))
@@ -31,6 +32,7 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(parser.sources, [])
         self.assertEqual(parser.packages, [])
         self.assertEqual(parser.setup, ['setupAll'])
+        self.assertEqual(parser.requirements, [])
 
     def test_config_parent(self):
         parent = config.Parser()


### PR DESCRIPTION
Some charms use tox to setup the virtualenv for bundletester to
run inside, including dependencies for the actual amulet tests
that get executed.

Add support to allow the requirements.txt/test-requirements.txt
files used in these configurations to also be used by bundletester
in a tests.yaml file, using a new requirements list:

   requirements:
     - test-requirements.txt
     - requirements.txt

Each file is verified to actually exist prior to use when installing
dependencies for the tests.

Closes #65