### PR TITLE
Mark as errors nonexistent makefile rules

### DIFF
--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -2,6 +2,8 @@ import yaml
 
 
 class Parser(dict):
+    DEFAULT_MAKE_TARGETS = ['lint', 'test']
+
     def __defaults__(self):
         return {
             'bootstrap': True,
@@ -18,7 +20,7 @@ class Parser(dict):
             'packages': [],
             'python_packages': [],
             'requirements': [],
-            'makefile': ['lint', 'test'],
+            'makefile': list(Parser.DEFAULT_MAKE_TARGETS),
             'setup': [],
             'teardown': []
         }
@@ -26,6 +28,7 @@ class Parser(dict):
     def __init__(self, path=None, parent=None, **kwargs):
         if not parent:
             parent = self.__defaults__()
+
         self.merge(parent)
         if kwargs:
             self.merge(kwargs)

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -2,7 +2,7 @@ import glob
 import os
 import subprocess
 from distutils.spawn import find_executable
-
+from config import Parser
 import yaml
 
 from bundletester import (config, models, utils)
@@ -232,8 +232,14 @@ class Suite(list):
         self.spec(proof,
                   dirname=self.model['directory'], suite=self)
         for target in (self.config.makefile or []):
-            self.conditional_make(target, self.model['directory'],
-                                  suite=self)
+            if target in Parser.DEFAULT_MAKE_TARGETS:
+                self.conditional_make(target, self.model['directory'],
+                                      suite=self)
+            else:
+                self.spec(['make', '-s', target],
+                          name="make {}".format(target),
+                          dirname=self.model['directory'],
+                          suite=self)
 
 
 def filter_yamls(yamls):


### PR DESCRIPTION
We got this case where a developer had misspelled a makefile target in the charms tests.yaml and did not notice that this test was not running for a long time. We would better mark non-existent makefile targets as errors.

I am not sure about the purpose of the  conditional_make, I might be missing something there.

This resolves: https://github.com/juju-solutions/bundletester/issues/75