### PR TITLE
Conditionally add matrix to tests

### DIFF
--- a/bin/test_setup
+++ b/bin/test_setup
@@ -11,6 +11,6 @@ if [ ! -d .venv ]; then
     pip install --upgrade pip
     pip install wheel
     pip install --use-wheel -f deps -r requirements.txt
-    pip install --use-wheel -f deps --no-index .
+    pip install --use-wheel -f deps --no-index -e .
 fi
 

--- a/bundletester/runner.py
+++ b/bundletester/runner.py
@@ -55,6 +55,7 @@ class Runner(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             cwd=cwd,
+            env=dict(os.environ, PYTHONIOENCODING='utf8'),
         )
 
         # Print all output as it comes in to debug

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ juju-deployer>=0.6.0
 lazr.authentication
 mock
 nose
-requests
+requests<=2.9.1
 simplejson>=3.8.0
 websocket-client


### PR DESCRIPTION
If Matrix is installed, it will be added to the tests for a bundle.

This depends on juju-solutions/matrix#43

Also has some small bug fixes as a drive-by:
* Pin `requests` requirement to match that from `charm-tools` (the venv is fine because of the wheelhouse, but installing creates a conflict because of the newer version of `requests` on pypi and the pinned version on `charm-tools`)
* Use `try` / `finally` instead of `atexit` for cleanup, because `atexit` was conflicting with CWR (juju-solutions/cloud-weather-report#85)