### PR TITLE
Fix KeyError on spec failure

### DIFF
--- a/bundletester/runner.py
+++ b/bundletester/runner.py
@@ -173,7 +173,10 @@ class Runner(object):
             yield self._run_test(spec)
 
     def _run_test(self, spec):
-        result = {}
+        result = {
+            'test': spec.name,
+            'returncode': 0
+        }
         cwd = os.getcwd()
         try:
             if spec.reset:


### PR DESCRIPTION
There seems to be a case where a test result can not get a name assigned.

```
ERROR:runner:Timeout exceeded. Failed to destroy all applications  in 60 seconds.
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/bundletester/runner.py", line 180, in _run_test
    self.builder.reset()
  File "/usr/local/lib/python2.7/dist-packages/bundletester/builder.py", line 140, in reset
    ' in %s seconds.' % timeout)
RuntimeError: Timeout exceeded. Failed to destroy all applications  in 60 seconds.
cs:~juju-solutions/cwr
Traceback (most recent call last):
  File "/usr/local/bin/bundletester", line 11, in <module>
    sys.exit(entrypoint())
  File "/usr/local/lib/python2.7/dist-packages/bundletester/tester.py", line 157, in entrypoint
    status = main()
  File "/usr/local/lib/python2.7/dist-packages/bundletester/tester.py", line 146, in main
    [report.emit(result) for result in run()]
  File "/usr/local/lib/python2.7/dist-packages/bundletester/reporter.py", line 147, in emit
    cmd = message.test
  File "/usr/local/lib/python2.7/dist-packages/bundletester/reporter.py", line 16, in __getattr__
    return self[k]
KeyError: 'test'
Build step 'Execute shell' marked build as failure
```