### PR TITLE
Ensure atexit cleanup doesn't error if the temp dir is already gone

### DIFF
--- a/bundletester/models.py
+++ b/bundletester/models.py
@@ -36,7 +36,7 @@ class Charm(FSEntity):
 
         charm_dir = os.path.join(tmp_dir, charm_name)
         shutil.copytree(dcharm.path, charm_dir, symlinks=True)
-        atexit.register(shutil.rmtree, tmp_dir)
+        atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
 
         c = cls()
         c['name'] = dcharm.name


### PR DESCRIPTION
CWR does a dumb thing and changes where temp dirs are created and then
deletes that out from under us in a misguided attempt to ensure that all
temp files are cleaned up.  I tend to prefer try / finally over atexit
in general, but there doesn't seem to be a clean way to do that here.
So, until CWR is fixed, this seems like the easiest fix, and still
reasonable.