### PR TITLE
Remove Deployer and use native juju deploy for Juju 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PYTHON := /usr/bin/env python
 PROJECT=bundletester
+TESTS=tests
 VERSION=$(shell cat VERSION)
 
 all: lint test

--- a/bundletester/reporter.py
+++ b/bundletester/reporter.py
@@ -178,16 +178,24 @@ class XMLReporter(Reporter):
         opts = self.options
         top = Element('testsuites')
 
-        testsuitename = "{}-{}".format(opts.testdir,
-                                       str(opts.fetcher.get_revision(opts.testdir)).strip())
-        testsuite = SubElement(top, 'testsuite', {"name": testsuitename, "tests": "{}".format(len(self.messages))})
+        testsuitename = "{}-{}".format(
+            opts.testdir,
+            str(opts.fetcher.get_revision(opts.testdir)).strip())
+        testsuite = SubElement(
+            top,
+            'testsuite',
+            {"name": testsuitename, "tests": "{}".format(len(self.messages))})
         for msg in self.messages:
-            testcase = SubElement(testsuite, 'testcase',
-                                  {"name": msg.test,
-                                   "classname": msg.suite,
-                                   "time": "{}".format(msg.get('duration', 0))})
+            testcase = SubElement(
+                testsuite,
+                'testcase',
+                {"name": msg.test, "classname": msg.suite, "time": "{}".format(
+                    msg.get('duration', 0))})
             if msg.returncode != 0:
-                errorelement = SubElement(testcase, 'error', {"message": self.get_error(msg)})
+                errorelement = SubElement(
+                    testcase,
+                    'error',
+                    {"message": self.get_error(msg)})
                 errorelement.text = msg.output
 
         self.fp.write(tostring(top, encoding="utf-8"))

--- a/bundletester/runner.py
+++ b/bundletester/runner.py
@@ -130,13 +130,22 @@ class Runner(object):
             stop = True
         return result, stop
 
+    @staticmethod
+    def wait_for_deployment(wait_cmd):
+        if wait_cmd:
+            log.info('Waiting for deployment to complete.')
+            status = subprocess.check_output(wait_cmd)
+            log.info('Waiting completed: {}'.format(status))
+
     def __call__(self):
         self.build()
         bootstrapped = self.builder.bootstrap()
         deploy_cmd = self.suite.deploy_cmd()
+        wait_cmd = self.suite.wait_cmd()
         if deploy_cmd:
             try:
                 self._deploy(deploy_cmd)
+                self.wait_for_deployment(wait_cmd)
             except DeployError as e:
                 yield e.result
                 raise StopIteration

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -106,6 +106,29 @@ class Suite(list):
                 return True
         return False
 
+    def _deployer_cmd(self, bundle):
+        cmd = ['juju-deployer']
+        if self.options.verbose:
+            cmd.append('-Wvd')
+        cmd += ['-c', bundle]
+        if self.options.deployment:
+            cmd.append(self.options.deployment)
+        if self.config.deployment_timeout is not None:
+            cmd += ['-t', str(self.config.deployment_timeout)]
+        return cmd
+
+    def _deploy_cmd(self, bundle):
+        cmd = ['juju', 'deploy', bundle]
+        return cmd
+
+    def wait_cmd(self):
+        if self.options.juju_major_version == 1:
+            return None
+        cmd = ['juju-wait', '-v']
+        if self.config.deployment_timeout is not None:
+            cmd.extend(['-t', str(self.config.deployment_timeout)])
+        return cmd
+
     def deploy_cmd(self):
         """Return the bundle deploy command for this suite.
 
@@ -128,14 +151,10 @@ class Suite(list):
                 return None
             if not os.path.exists(bundle):
                 raise OSError("Missing required bundle file: %s" % bundle)
-            cmd = ['juju-deployer']
-            if self.options.verbose:
-                cmd.append('-Wvd')
-            cmd += ['-c', bundle]
-            if self.options.deployment:
-                cmd.append(self.options.deployment)
-            if self.config.deployment_timeout is not None:
-                cmd += ['-t', str(self.config.deployment_timeout)]
+            if self.options.juju_major_version == 1:
+                cmd = self._deployer_cmd(bundle)
+            else:
+                cmd = self._deploy_cmd(bundle)
             return cmd
         else:
             # self.config.bundle_deploy is a file name

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -119,6 +119,8 @@ class Suite(list):
 
     def _deploy_cmd(self, bundle):
         cmd = ['juju', 'deploy', bundle]
+        if self.options.deployment:
+            cmd.append(self.options.deployment)
         return cmd
 
     def wait_cmd(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ nose
 requests<=2.9.1
 simplejson>=3.8.0
 websocket-client
+juju-wait

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -16,7 +16,8 @@ class TestBuilder(unittest.TestCase):
         parser = config.Parser()
         b = builder.Builder(parser, None)
         b.build_virtualenv('venv')
-        self.assertEqual(mcall.call_args[0][0], ['virtualenv', '-p', 'python', 'venv'])
+        self.assertEqual(mcall.call_args[0][0],
+                         ['virtualenv', '-p', 'python', 'venv'])
 
     @mock.patch('subprocess.check_call')
     def test_builder_sources(self, mcall):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -52,7 +52,8 @@ class TestReporter(unittest.TestCase):
     def test_xml_reporter(self):
         output = self.get_report_output("XML")
         tree = ElementTree.fromstring(output)
-        self.assertEqual(tree.findall('testsuite')[0].attrib['name'], "/tmp/test-1")
+        self.assertEqual(tree.findall('testsuite')[0].attrib['name'],
+                         "/tmp/test-1")
         self.assertEqual(tree.findall('testsuite')[0]
                          .findall("testcase")[1]
                          .find('error').attrib['message'], "Unknown")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -23,6 +23,12 @@ class O(object):
 class TestRunner(unittest.TestCase):
 
     def test_run_suite(self):
+        self.run_suite(juju_major_version=2)
+
+    def test_run_suite_juju_1(self):
+        self.run_suite(juju_major_version=1)
+
+    def run_suite(self, juju_major_version):
         logging.basicConfig(level=logging.CRITICAL)
         parser = config.Parser()
         parser.bootstrap = False
@@ -30,7 +36,8 @@ class TestRunner(unittest.TestCase):
         options.dryrun = True
         options.environment = 'local'
         options.failfast = True
-        options.tests_yaml=None
+        options.tests_yaml = None
+        options.juju_major_version = juju_major_version
         model = models.TestDir({'name': 'testdir',
                                 'directory': TEST_FILES,
                                 'testdir': TEST_FILES})


### PR DESCRIPTION
- Use native juju deploy for Juju 2.0. The Deployer is still used for Juju 1.0
- Updated unit tests.
- Updated Makefile to include the `tests` dir for lint checking. 
- Added juju-wait to the requirements.txt file.
- Fixed some lint error.