### PR TITLE
Improve connection and timeout handling during reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Explanation of keys:
 
 **reset**: Use juju-deployer to reset the model between each test file execution (default: true).
 
-**reset_timeout**: Max time (in seconds) allowed for each of two routines in a model reset:  machine termination, and application removal.  Total wait time can be 2X this value.  This option has no effect if `reset` has any value other than `true` (default: 60).
+**reset_timeout**: Max time (in seconds) allowed for each of two routines in a model reset:  machine termination, and application removal.  Total wait time can be 2X this value.  This option has no effect if `reset` has any value other than `true` (default: 180).
 
 **virtualenv**: Create and activate a virtualenv in which all tests are run (default: false).
 

--- a/bundletester/config.py
+++ b/bundletester/config.py
@@ -8,7 +8,7 @@ class Parser(dict):
         return {
             'bootstrap': True,
             'reset': True,
-            'reset_timeout': 60,
+            'reset_timeout': 60 * 3,
             'bundle': None,
             'bundle_deploy': True,
             'deployment_timeout': None,


### PR DESCRIPTION
Having the default reset timeout be the same as the force terminate timeout means the latter won't have a chance to work.  There are also some connection errors that can occur that don't seem to be instances of websocket.WebSocketConnectionClosedException.

Examples of connection errors that weren't being reconnected:

```
2017-02-22 00:04:50 ERROR [Errno 110] Connection timed out
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/bundletester/builder.py", line 107, in reset
    force_terminate=True
  File "/usr/local/lib/python2.7/dist-packages/deployer/env/go.py", line 102, in reset
    status = self.status()
  File "/usr/local/lib/python2.7/dist-packages/deployer/env/go.py", line 247, in status
    return NormalizedStatus(self.client.status())
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/environment.py", line 506, in status
    return self.client.status(*args, **kws)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/juju2/facades.py", line 383, in status
    'params': {'patterns': filters}})
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/facades.py", line 72, in rpc
    return self.env._rpc(self.check_op(op))
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 38, in _rpc
    result = self._rpc_retry_if_upgrading(op)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 51, in _rpc_retry_if_upgrading
    result = self._send_request(op)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 64, in _send_request
    self.conn.send(json.dumps(op))
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 234, in send
    return self.send_frame(frame)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 259, in send_frame
    l = self._send(data)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 423, in _send
    return send(self.sock, data)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_socket.py", line 116, in send
    return sock.send(data)
  File "/usr/lib/python2.7/ssl.py", line 709, in send
    v = self._sslobj.write(data)
error: [Errno 110] Connection timed out
2017-02-22 00:04:51 ERROR [Errno 32] Broken pipe
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/bundletester/builder.py", line 107, in reset
    force_terminate=True
  File "/usr/local/lib/python2.7/dist-packages/deployer/env/go.py", line 102, in reset
    status = self.status()
  File "/usr/local/lib/python2.7/dist-packages/deployer/env/go.py", line 247, in status
    return NormalizedStatus(self.client.status())
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/environment.py", line 506, in status
    return self.client.status(*args, **kws)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/juju2/facades.py", line 383, in status
    'params': {'patterns': filters}})
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/facades.py", line 72, in rpc
    return self.env._rpc(self.check_op(op))
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 38, in _rpc
    result = self._rpc_retry_if_upgrading(op)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 51, in _rpc_retry_if_upgrading
    result = self._send_request(op)
  File "/usr/local/lib/python2.7/dist-packages/jujuclient/rpc.py", line 64, in _send_request
    self.conn.send(json.dumps(op))
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 234, in send
    return self.send_frame(frame)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 259, in send_frame
    l = self._send(data)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_core.py", line 423, in _send
    return send(self.sock, data)
  File "/usr/local/lib/python2.7/dist-packages/websocket/_socket.py", line 116, in send
    return sock.send(data)
  File "/usr/lib/python2.7/ssl.py", line 709, in send
    v = self._sslobj.write(data)
error: [Errno 32] Broken pipe
```