### PR TITLE
Add snapcraft recipe

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,27 @@
+name: bundletester
+version: "0.11.0"  # same value in VERSION file
+summary: A juju charm and bundle test runner
+description: |
+  This is designed around the fail fast principle. Each bundle is composed of
+  charms, each of those charms should have tests ranging from unit tests to
+  integration tests. The bundle itself will have integration tests. Those
+  tests should run from least expensive to most expensive in terms of time,
+  failing as soon as possible. The theory is that if tests fail in the charms,
+  the bundle cannot function. Bundletester will therefore pull all the charms
+  and look for any tests it can find and run those prior running its own
+  integration tests.  
+grade: devel
+confinement: classic
+apps:
+  bundletester:
+    command: bin/bundletester
+  bundlewatcher:
+    command: bin/bundlewatcher
+parts:
+  bundletester:
+    plugin: python
+    python-version: python2
+    source: ./
+    build-packages:
+      - python-dev
+      - build-essential


### PR DESCRIPTION
This patch adds snapcraft.yaml to build a snap of bundlester. It exposes
bundletester and bundlewatcher commands

Something I haven't figured out correctly is how to inject the snap's version dynamically, in a similar way "make release" does it, without having to play with sed.

I'm putting this for early feedback, but it is fully functional, I'm using bundletester from a snap on a daily basis without issues so far.