### PR TITLE
Set JUJU_MODEL environment variable for Juju 2

### DIFF
--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -115,10 +115,14 @@ class Suite(list):
             cmd.append(self.options.deployment)
         if self.config.deployment_timeout is not None:
             cmd += ['-t', str(self.config.deployment_timeout)]
+        if self.options.environment:
+            cmd.extend(['-e', self.options.environment])
         return cmd
 
     def _deploy_cmd(self, bundle):
         cmd = ['juju', 'deploy', bundle]
+        if self.options.environment:
+            cmd.extend(['-m', self.options.environment])
         if self.options.deployment:
             cmd.append(self.options.deployment)
         if self.options.deploy_plan:
@@ -131,6 +135,8 @@ class Suite(list):
         if self.options.juju_major_version == 1:
             return None
         cmd = ['juju-wait', '-v']
+        if self.options.environment:
+            cmd.extend(['-m', self.options.environment])
         if self.config.deployment_timeout is not None:
             cmd.extend(['-t', str(self.config.deployment_timeout)])
         return cmd

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -147,7 +147,8 @@ def main(options=None):
         run = runner.Runner(suite, options)
         report.header()
         if len(suite):
-            with utils.juju_env(options.environment):
+            with utils.juju_env(
+                    options.environment, options.juju_major_version):
                 [report.emit(result) for result in run()]
         report.summary()
         return_code = report.exit()

--- a/bundletester/utils.py
+++ b/bundletester/utils.py
@@ -30,14 +30,17 @@ def find_testdir(directory):
 
 
 @contextmanager
-def juju_env(env):
-    orig_env = os.environ.get('JUJU_ENV', '')
+def juju_env(env, juju_major_version):
+    juju_model = 'JUJU_MODEL'
+    if juju_major_version == 1:
+        juju_model = 'JUJU_ENV'
+    orig_env = os.environ.get(juju_model, '')
     if env != orig_env:
-        log.debug('Updating JUJU_ENV: "%s" -> "%s"', orig_env, env)
-        os.environ['JUJU_ENV'] = env
+        log.debug('Updating %s: "%s" -> "%s"', juju_model, orig_env, env)
+        os.environ[juju_model] = env
     try:
         yield
     finally:
         if env != orig_env:
-            log.debug('Updating JUJU_ENV: "%s" -> "%s"', env, orig_env)
-            os.environ['JUJU_ENV'] = orig_env
+            log.debug('Updating %s: "%s" -> "%s"', juju_model, env, orig_env)
+            os.environ[juju_model] = orig_env

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -218,6 +218,15 @@ class TestDeployCommand(unittest.TestCase):
         self.assertEqual(cmd, ['juju', 'deploy', 'foo-bundle', '--plan', 'foo',
                                '--budget', 'bar'])
 
+    def test_deploy_cmd_env(self):
+        model = fake_model()
+        options = FakeOptions(juju_major_version=2)
+        options.environment = 'foo'
+
+        suite = spec.Suite(model, options)
+        cmd = suite._deploy_cmd('foo-bundle')
+        self.assertEqual(cmd, ['juju', 'deploy', 'foo-bundle', '-m', 'foo'])
+
 
 def fake_model():
     return models.Bundle({
@@ -233,6 +242,7 @@ class FakeOptions:
     deployment = None
     deploy_plan = None
     deploy_budget = None
+    environment = None
 
     def __init__(self, juju_major_version):
         self.juju_major_version = juju_major_version


### PR DESCRIPTION
This branch sets `JUJU_MODEL` instead of `JUJU_ENV` variable for Juju 2. Also,  sets `-m` when deploying using `juju deploy`.
 
This fixes issue #93 . `BT` was deploying to the default controller:model rather than the controller:model specified by the code.