### PR TITLE
Added option to turn juju-matrix off during a test run.

### DIFF
--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -268,8 +268,10 @@ class Suite(list):
         if self.options.juju_major_version < 2:
             # matrix currently requires Juju 2.0+
             return
+        if self.options.no_chaos:
+            return
         try:
-            subprocess.call(['matrix', '--help'],
+            subprocess.call(['juju-matrix', '--help'],
                             stdout=open('/dev/null', 'w'),
                             stderr=subprocess.STDOUT)
         except OSError as e:
@@ -277,8 +279,8 @@ class Suite(list):
                 raise
         else:
             controller, _ = self.options.environment.split(':')
-            self.spec(['matrix', '-s', 'raw', '-c', controller],
-                      name='matrix', dirname=dirname)
+            self.spec(['juju-matrix', '-s', 'raw', '-c', controller],
+                      name='juju-matrix', dirname=dirname)
 
     def find_implicit_tests(self):
         # Look for implicit targets and map these as tests

--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -268,7 +268,7 @@ class Suite(list):
         if self.options.juju_major_version < 2:
             # matrix currently requires Juju 2.0+
             return
-        if self.options.no_chaos:
+        if self.options.no_matrix:
             return
         try:
             subprocess.call(['juju-matrix', '--help'],

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -83,6 +83,9 @@ def configure():
                         help='A plan to deploy charm under')
     parser.add_argument('--deploy-budget',
                         help='Deploy budget and allocation limit')
+    parser.add_argument('--no-chaos', action="store_true",
+                        help="Skip matrix test run, even if juju-matrix is "
+                        "in your path.")
     options = parser.parse_args()
 
     if options.version:

--- a/bundletester/tester.py
+++ b/bundletester/tester.py
@@ -83,7 +83,7 @@ def configure():
                         help='A plan to deploy charm under')
     parser.add_argument('--deploy-budget',
                         help='Deploy budget and allocation limit')
-    parser.add_argument('--no-chaos', action="store_true",
+    parser.add_argument('--no-matrix', action="store_true",
                         help="Skip matrix test run, even if juju-matrix is "
                         "in your path.")
     options = parser.parse_args()


### PR DESCRIPTION
Helps in charmbox, where juju-matrix is installed by default, but people
may not want to wait for a full matrix run when running bundletester.

@johnsca @chuckbutler @kwmonroe Addresses https://github.com/juju-solutions/bundletester/issues/103