### PR TITLE
Filter out metrics.yaml form the yamls potentialy containing bundle

### DIFF
--- a/bundletester/spec.py
+++ b/bundletester/spec.py
@@ -311,6 +311,8 @@ def filter_yamls(yamls):
 
     result = []
     for yamlfn in yamls:
+        if yamlfn.endswith('metrics.yaml'):
+            continue
         data = yaml.safe_load(open(yamlfn))
         if not isinstance(data, dict):
             continue


### PR DESCRIPTION
We should be skipping the metrics.yaml file because BT assumes it containing a bundle.

Here is the error produced: https://github.com/kubernetes/kubernetes/issues/45482
And the exception: http://pastebin.ubuntu.com/24536198/
